### PR TITLE
Disable proposal of replacing `and` with `&&` in controller render flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/
 /.bundle/
 /.yardoc
 /_yardoc/

--- a/default.yml
+++ b/default.yml
@@ -29,3 +29,6 @@ Style/Documentation:
 Style/MixinUsage:
   Exclude:
     - 'bin/*'
+
+Style/AndOr:
+  EnforcedStyle: conditionals

--- a/lib/glossgenius_style/version.rb
+++ b/lib/glossgenius_style/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GlossgeniusStyle
-  VERSION = '0.1.7'
+  VERSION = '0.1.8'
 end


### PR DESCRIPTION
Here is why:
1) Swapping `and` with `&&` in controller render flow breaks precedence and creates invalid code
2) This is a _valid_ trick according to official Rails documentation
3) Workarounds produce ugly multiline `return (nil intended)`
4) I am getting annoyed with this cop in legacy code
