### PR TITLE
Rename outdated cop, which was breaking the CI checks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    glossgenius_style (0.1.7)
+    glossgenius_style (0.1.9)
       rubocop (~> 0.76.0)
       rubocop-rspec (~> 1.36.0)
 
@@ -11,11 +11,11 @@ GEM
     ast (2.4.0)
     diff-lcs (1.3)
     jaro_winkler (1.5.4)
-    parallel (1.18.0)
+    parallel (1.19.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)
     rainbow (3.0.0)
-    rake (13.0.0)
+    rake (13.0.1)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -45,10 +45,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16.1)
+  bundler (~> 2.0)
   glossgenius_style!
   rake (~> 13.0.0)
   rspec (~> 3.9.0)
 
 BUNDLED WITH
-   1.16.1
+   2.0.2

--- a/default.yml
+++ b/default.yml
@@ -14,7 +14,7 @@ Metrics/BlockLength:
 Metrics/LineLength:
   Max: 120
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
 RSpec/NestedGroups:

--- a/glossgenius_style.gemspec
+++ b/glossgenius_style.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rubocop', '~> 0.76.0'
   spec.add_dependency 'rubocop-rspec', '~> 1.36.0'
-  spec.add_development_dependency 'bundler', '~> 1.16.1'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0.0'
   spec.add_development_dependency 'rspec', '~> 3.9.0'
 end

--- a/lib/glossgenius_style/version.rb
+++ b/lib/glossgenius_style/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GlossgeniusStyle
-  VERSION = '0.1.8'
+  VERSION = '0.1.9'
 end


### PR DESCRIPTION
```shell
Run git diff --diff-filter=AM --name-status origin/integration | xargs rubocop --force-exclusion
Error: The `Layout/IndentFirstArrayElement` cop has been renamed to `Layout/FirstArrayElementIndentation`.
(obsolete configuration found in /opt/hostedtoolcache/Ruby/2.6.3/x64/lib/ruby/gems/2.6.0/gems/glossgenius_style-0.1.8/default.yml, please update it)
##[error]Process completed with exit code 123.
```