### PR TITLE
Update 0.1.10

### DIFF
--- a/.github/workflows/ruby_release_gem.yml
+++ b/.github/workflows/ruby_release_gem.yml
@@ -20,7 +20,7 @@ jobs:
       - name: set up ruby
         uses: actions/setup-ruby@v1
         with:
-          version: 2.6.x
+          ruby-version: 2.6.x
 
       - name: manage token(s) for package registry(s)
         run: |

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     glossgenius_style (0.1.9)
-      rubocop (~> 0.76.0)
-      rubocop-rspec (~> 1.36.0)
+      rubocop (~> 0.81.0)
+      rubocop-rspec (~> 1.38.1)
 
 GEM
   remote: https://rubygems.org/
@@ -12,10 +12,11 @@ GEM
     diff-lcs (1.3)
     jaro_winkler (1.5.4)
     parallel (1.19.1)
-    parser (2.6.5.0)
+    parser (2.7.1.0)
       ast (~> 2.4.0)
     rainbow (3.0.0)
     rake (13.0.1)
+    rexml (3.2.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -29,17 +30,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
-    rubocop (0.76.0)
+    rubocop (0.81.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.6)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-rspec (1.36.0)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-rspec (1.38.1)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
-    unicode-display_width (1.6.0)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    glossgenius_style (0.1.9)
+    glossgenius_style (0.1.10)
       rubocop (~> 0.81.0)
       rubocop-rspec (~> 1.38.1)
 

--- a/default.yml
+++ b/default.yml
@@ -26,6 +26,9 @@ Style/ClassAndModuleChildren:
 Style/Documentation:
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: always
+
 Style/MixinUsage:
   Exclude:
     - 'bin/*'

--- a/glossgenius_style.gemspec
+++ b/glossgenius_style.gemspec
@@ -7,8 +7,8 @@ require 'glossgenius_style/version'
 Gem::Specification.new do |spec|
   spec.name          = 'glossgenius_style'
   spec.version       = GlossgeniusStyle::VERSION
-  spec.authors       = ['GlossGenius']
-  spec.email         = ['support@glossgenius.com']
+  spec.author        = 'GlossGenius'
+  spec.email         = 'support@glossgenius.com'
 
   spec.summary       = 'Ruby Style Guide for GlossGenius engineering team'
   spec.homepage      = 'https://github.com/GlossGenius/ruby-style-guide'

--- a/glossgenius_style.gemspec
+++ b/glossgenius_style.gemspec
@@ -7,8 +7,8 @@ require 'glossgenius_style/version'
 Gem::Specification.new do |spec|
   spec.name          = 'glossgenius_style'
   spec.version       = GlossgeniusStyle::VERSION
-  spec.authors       = ['Alexey Cherkashin']
-  spec.email         = ['goodniceweb@gmail.com']
+  spec.authors       = ['GlossGenius']
+  spec.email         = ['support@glossgenius.com']
 
   spec.summary       = 'Ruby Style Guide for GlossGenius engineering team'
   spec.homepage      = 'https://github.com/GlossGenius/ruby-style-guide'
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.76.0'
-  spec.add_dependency 'rubocop-rspec', '~> 1.36.0'
+  spec.add_runtime_dependency 'rubocop', '~> 0.81.0'
+  spec.add_runtime_dependency 'rubocop-rspec', '~> 1.38.1'
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0.0'
   spec.add_development_dependency 'rspec', '~> 3.9.0'

--- a/lib/glossgenius_style/version.rb
+++ b/lib/glossgenius_style/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GlossgeniusStyle
-  VERSION = '0.1.9'
+  VERSION = '0.1.10'
 end


### PR DESCRIPTION
- Updated `rubocop` and `rubocop-rspec` dependencies 
- Enforced Style/FrozenStringLiteralComment
- Corrected README.md
- Fixed Github Actions deprecation warning